### PR TITLE
Add compact mark

### DIFF
--- a/benchmark/FastRoute/FastRouteCompactMarkBased.php
+++ b/benchmark/FastRoute/FastRouteCompactMarkBased.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace BenchmarkRouting\FastRoute;
+
+use FastRoute\DataGenerator;
+use FastRoute\Dispatcher;
+use PhpBench\Attributes as Bench;
+
+#[Bench\Groups(['fast-route', 'raw'])]
+final class FastRouteCompactMarkBased extends AbstractFastRoute
+{
+    protected string $dataGeneratorClass = DataGenerator\CompactMarkBased::class;
+    protected string $dispatcherClass = Dispatcher\CompactMarkBased::class;
+}

--- a/benchmark/FastRoute/FastRouteCompactMarkBasedApcuCached.php
+++ b/benchmark/FastRoute/FastRouteCompactMarkBasedApcuCached.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace BenchmarkRouting\FastRoute;
+
+use FastRoute\Cache\ApcuCache;
+use FastRoute\DataGenerator;
+use FastRoute\Dispatcher;
+use PhpBench\Attributes as Bench;
+
+#[Bench\Groups(['fast-route', 'cached'])]
+final class FastRouteCompactMarkBasedApcuCached extends AbstractFastRoute
+{
+    protected string $dataGeneratorClass = DataGenerator\CompactMarkBased::class;
+    protected string $dispatcherClass = Dispatcher\CompactMarkBased::class;
+
+    public function __construct()
+    {
+        $this->cacheDriver = ApcuCache::class;
+        $this->cacheKey = 'fast-route-compact-mark-based';
+
+        $this->createDispatcher();
+    }
+}

--- a/benchmark/FastRoute/FastRouteCompactMarkBasedFilesCached.php
+++ b/benchmark/FastRoute/FastRouteCompactMarkBasedFilesCached.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace BenchmarkRouting\FastRoute;
+
+use FastRoute\Cache\FileCache;
+use FastRoute\DataGenerator;
+use FastRoute\Dispatcher;
+use PhpBench\Attributes as Bench;
+
+#[Bench\Groups(['fast-route', 'cached'])]
+final class FastRouteCompactMarkBasedFilesCached extends AbstractFastRoute
+{
+    protected string $dataGeneratorClass = DataGenerator\CompactMarkBased::class;
+    protected string $dispatcherClass = Dispatcher\CompactMarkBased::class;
+
+    public function __construct()
+    {
+        $this->cacheDriver = FileCache::class;
+        $this->cacheKey = __DIR__ . '/../../cache/fast-route-compact-mark-based.php';
+
+        $this->createDispatcher();
+    }
+}

--- a/benchmark/FastRoute/FastRouteCompactMarkBasedInstance.php
+++ b/benchmark/FastRoute/FastRouteCompactMarkBasedInstance.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace BenchmarkRouting\FastRoute;
+
+use FastRoute\DataGenerator;
+use FastRoute\Dispatcher;
+use PhpBench\Attributes as Bench;
+
+#[Bench\Groups(['fast-route', 'instance'])]
+final class FastRouteCompactMarkBasedInstance extends AbstractFastRouteInstance
+{
+    protected string $dataGeneratorClass = DataGenerator\CompactMarkBased::class;
+    protected string $dispatcherClass = Dispatcher\CompactMarkBased::class;
+}

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "ext-apcu": "*",
     "phpbench/phpbench": "^1.0",
     "symfony/routing": "^4.4",
-    "nikic/fast-route": "^2.0@dev",
+    "nikic/fast-route": "dev-implement-new-dispatcher@dev",
     "azjezz/hack-routing": "dev-main",
     "symfony/config": "^5.3"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "969b8242a1d65169eba9b7b1525e6e70",
+    "content-hash": "af34fd73208987bedf5b61e06efc8a28",
     "packages": [
         {
             "name": "azjezz/hack-routing",
@@ -281,16 +281,16 @@
         },
         {
             "name": "nikic/fast-route",
-            "version": "dev-master",
+            "version": "dev-implement-new-dispatcher",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/FastRoute.git",
-                "reference": "ea5d3abe8b9fc7d63bb42b0384cb1db60972ff68"
+                "reference": "dd5d2fec20eea7ad8565b9420ae2e723186aefa0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/FastRoute/zipball/ea5d3abe8b9fc7d63bb42b0384cb1db60972ff68",
-                "reference": "ea5d3abe8b9fc7d63bb42b0384cb1db60972ff68",
+                "url": "https://api.github.com/repos/nikic/FastRoute/zipball/dd5d2fec20eea7ad8565b9420ae2e723186aefa0",
+                "reference": "dd5d2fec20eea7ad8565b9420ae2e723186aefa0",
                 "shasum": ""
             },
             "require": {
@@ -309,7 +309,6 @@
             "suggest": {
                 "ext-apcu": "To be able to use APCu cache driver"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -341,9 +340,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/FastRoute/issues",
-                "source": "https://github.com/nikic/FastRoute/tree/master"
+                "source": "https://github.com/nikic/FastRoute/tree/implement-new-dispatcher"
             },
-            "time": "2021-06-21T15:01:25+00:00"
+            "time": "2021-07-06T22:09:01+00:00"
         },
         {
             "name": "phpbench/container",

--- a/scripts/quick-benchmark.php
+++ b/scripts/quick-benchmark.php
@@ -21,6 +21,7 @@ final class QuickBenchmark
             'symfony' => Symfony\Symfony::class,
             'hack-routing' => HackRouting\HackRouting::class,
             'fast-route(mark)' => FastRoute\FastRouteMarkBased::class,
+            'fast-route(compact-mark)' => FastRoute\FastRouteCompactMarkBased::class,
         ],
 
         'cached' => [
@@ -30,6 +31,8 @@ final class QuickBenchmark
             'hack-routing:cached(apcu)' => HackRouting\HackRoutingApcuCached::class,
             'fast-route(mark):cached(file)' => FastRoute\FastRouteMarkBasedFilesCached::class,
             'fast-route(mark):cached(apcu)' => FastRoute\FastRouteMarkBasedApcuCached::class,
+            'fast-route(compact-mark):cached(file)' => FastRoute\FastRouteCompactMarkBasedFilesCached::class,
+            'fast-route(compact-mark):cached(apcu)' => FastRoute\FastRouteCompactMarkBasedApcuCached::class,
         ],
 
         'instance' => [
@@ -37,6 +40,7 @@ final class QuickBenchmark
             'symfony:instance' => Symfony\SymfonyInstance::class,
             'hack-routing:instance' => HackRouting\HackRoutingInstance::class,
             'fast-route(mark):instance' => FastRoute\FastRouteMarkBasedInstance::class,
+            'fast-route(compact-mark):instance' => FastRoute\FastRouteCompactMarkBasedInstance::class,
         ]
     ];
 


### PR DESCRIPTION
This is still a very early thing... I just wanted to have it prepared to track the evolution of https://github.com/nikic/FastRoute/pull/244

Relevant results so far (on my machine again):

```sh
+---------------------------------- Benchmark results for group cached. -----------------+-----------------+
| Case                                  | Scenario           | Routes | Time             | Per Second      |
+---------------------------------------+--------------------+--------+------------------+-----------------+
| fast-route(compact-mark):cached(file) | benchAll           | 364    | 0.001499 seconds | 242838.66009226 |
| fast-route(compact-mark):cached(file) | benchInvalidRoute  | 300    | 0.001253 seconds | 239400.91324201 |
| fast-route(compact-mark):cached(file) | benchLast          | 300    | 0.001407 seconds | 213233.55363498 |
| fast-route(compact-mark):cached(file) | benchInvalidMethod | 300    | 0.001442 seconds | 208016.39940485 |
| symfony:cached(file)                  | benchInvalidRoute  | 300    | 0.001609 seconds | 186441.13201956 |
| symfony:cached(file)                  | benchAll           | 364    | 0.002281 seconds | 159565.91304347 |
| symfony:cached(file)                  | benchLast          | 300    | 0.001993 seconds | 150513.3014354  |
| fast-route(mark):cached(file)         | benchInvalidRoute  | 300    | 0.002399 seconds | 125053.78652356 |
| fast-route(mark):cached(file)         | benchInvalidMethod | 300    | 0.002713 seconds | 110570.40421793 |
| symfony:cached(file)                  | benchInvalidMethod | 300    | 0.002855 seconds | 105076.50939457 |
| fast-route(mark):cached(file)         | benchAll           | 364    | 0.003699 seconds | 98409.607838083 |
| fast-route(mark):cached(file)         | benchLast          | 300    | 0.004783 seconds | 62723.254075072 |
| fast-route(compact-mark):cached(apcu) | benchInvalidRoute  | 300    | 0.019989 seconds | 15008.244274809 |
| fast-route(compact-mark):cached(apcu) | benchAll           | 364    | 0.025139 seconds | 14479.57754173  |
| fast-route(compact-mark):cached(apcu) | benchLast          | 300    | 0.020992 seconds | 14291.130873284 |
| fast-route(compact-mark):cached(apcu) | benchInvalidMethod | 300    | 0.021273 seconds | 14102.293053594 |
| fast-route(mark):cached(apcu)         | benchInvalidRoute  | 300    | 0.021399 seconds | 14019.332843104 |
| fast-route(mark):cached(apcu)         | benchInvalidMethod | 300    | 0.021593 seconds | 13893.330977829 |
| fast-route(mark):cached(apcu)         | benchLast          | 300    | 0.021600 seconds | 13888.883737872 |
| fast-route(mark):cached(apcu)         | benchAll           | 364    | 0.026225 seconds | 13879.964143825 |
| fast-route(compact-mark):cached(file) | benchLongest       | 300    | 0.034367 seconds | 8729.2828104838 |
| symfony:cached(file)                  | benchLongest       | 300    | 0.034960 seconds | 8581.2279636918 |
| fast-route(mark):cached(file)         | benchLongest       | 300    | 0.037793 seconds | 7937.9945115605 |
| hack-routing:cached(file)             | benchLast          | 300    | 0.043581 seconds | 6883.7323296424 |
| hack-routing:cached(apcu)             | benchInvalidRoute  | 300    | 0.043625 seconds | 6876.7724905315 |
| hack-routing:cached(file)             | benchInvalidRoute  | 300    | 0.043763 seconds | 6855.1180844979 |
| hack-routing:cached(file)             | benchAll           | 364    | 0.053779 seconds | 6768.4254541908 |
| hack-routing:cached(apcu)             | benchAll           | 364    | 0.056535 seconds | 6438.488797048  |
| hack-routing:cached(file)             | benchInvalidMethod | 300    | 0.048739 seconds | 6155.2405271345 |
| hack-routing:cached(apcu)             | benchInvalidMethod | 300    | 0.051117 seconds | 5868.8955223881 |
| hack-routing:cached(apcu)             | benchLast          | 300    | 0.052316 seconds | 5734.3888000218 |
| fast-route(compact-mark):cached(apcu) | benchLongest       | 300    | 0.053404 seconds | 5617.5469769145 |
| fast-route(mark):cached(apcu)         | benchLongest       | 300    | 0.054406 seconds | 5514.1050417406 |
| hack-routing:cached(file)             | benchLongest       | 300    | 0.078200 seconds | 3836.3121389046 |
| hack-routing:cached(apcu)             | benchLongest       | 300    | 0.108145 seconds | 2774.0533914764 |
+---------------------------------------+--------------------+--------+------------------+-----------------+
+------------------------------- Benchmark results for group instance. --------------+-----------------+
| Case                              | Scenario           | Routes | Time             | Per Second      |
+-----------------------------------+--------------------+--------+------------------+-----------------+
| fast-route(compact-mark):instance | benchAll           | 364    | 0.000430 seconds | 846770.19190238 |
| fast-route(compact-mark):instance | benchLast          | 300    | 0.000489 seconds | 613501.31643102 |
| fast-route(compact-mark):instance | benchInvalidMethod | 300    | 0.000494 seconds | 607283.39768339 |
| symfony:instance                  | benchInvalidRoute  | 300    | 0.000519 seconds | 577993.20165365 |
| symfony:instance                  | benchAll           | 364    | 0.000665 seconds | 547410.05951954 |
| hack-routing:instance             | benchInvalidRoute  | 300    | 0.000551 seconds | 544479.09995673 |
| fast-route(compact-mark):instance | benchInvalidRoute  | 300    | 0.000684 seconds | 438581.80550715 |
| hack-routing:instance             | benchLast          | 300    | 0.000714 seconds | 420270.94188377 |
| symfony:instance                  | benchLast          | 300    | 0.000756 seconds | 396812.10974456 |
| symfony:instance                  | benchInvalidMethod | 300    | 0.001152 seconds | 260407.94701986 |
| hack-routing:instance             | benchAll           | 364    | 0.001424 seconds | 255604.66365311 |
| hack-routing:instance             | benchInvalidMethod | 300    | 0.001313 seconds | 228489.41347376 |
| fast-route(mark):instance         | benchLast          | 300    | 0.001412 seconds | 212477.40628165 |
| fast-route(mark):instance         | benchInvalidMethod | 300    | 0.001462 seconds | 205200.78277886 |
| fast-route(mark):instance         | benchAll           | 364    | 0.002135 seconds | 170488.73880514 |
| fast-route(mark):instance         | benchInvalidRoute  | 300    | 0.001933 seconds | 155191.31721756 |
| fast-route(compact-mark):instance | benchLongest       | 300    | 0.031924 seconds | 9397.315887348  |
| symfony:instance                  | benchLongest       | 300    | 0.032054 seconds | 9359.1520696194 |
| hack-routing:instance             | benchLongest       | 300    | 0.033415 seconds | 8977.9826332652 |
| fast-route(mark):instance         | benchLongest       | 300    | 0.034231 seconds | 8763.9993034999 |
+-----------------------------------+--------------------+--------+------------------+-----------------+
```